### PR TITLE
Move ml4bio launch in Windows script

### DIFF
--- a/scripts/install_launch_windows.bat
+++ b/scripts/install_launch_windows.bat
@@ -10,7 +10,11 @@ IF %ERRORLEVEL% NEQ 0 (
   ECHO creating ml4bio environment
   conda env create -f conda_env.yml
   CALL activate ml4bio
+  @REM launch the GUI
+  @REM this does not run as expected if it is placed outside the IF block
+  @REM so it is copied in the IF and ELSE block
+  ml4bio
+) ELSE (
+  @REM launch the GUI
+  ml4bio
 )
-
-@REM launch the GUI
-ml4bio


### PR DESCRIPTION
Closes #21

I wasn't able to debug why the `ml4bio` command doesn't work after the `IF` statement so I made a redundant copy.  I'm merging this without review because it is a small change that I tested mysef.